### PR TITLE
enable CMAKE_BUILD_TYPE MinSizeRel

### DIFF
--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -103,15 +103,17 @@ endif(NOT AVR_MCU)
 ##########################################################################
 if(NOT ((CMAKE_BUILD_TYPE MATCHES Release) OR
         (CMAKE_BUILD_TYPE MATCHES RelWithDebInfo) OR
-        (CMAKE_BUILD_TYPE MATCHES Debug)))
+        (CMAKE_BUILD_TYPE MATCHES Debug) OR
+        (CMAKE_BUILD_TYPE MATCHES MinSizeRel)))
    set(
       CMAKE_BUILD_TYPE Release
-      CACHE STRING "Choose cmake build type: Debug Release RelWithDebInfo"
+      CACHE STRING "Choose cmake build type: Debug Release RelWithDebInfo MinSizeRel"
       FORCE
    )
 endif(NOT ((CMAKE_BUILD_TYPE MATCHES Release) OR
            (CMAKE_BUILD_TYPE MATCHES RelWithDebInfo) OR
-           (CMAKE_BUILD_TYPE MATCHES Debug)))
+           (CMAKE_BUILD_TYPE MATCHES Debug) OR
+           (CMAKE_BUILD_TYPE MATCHES MinSizeRel)))
 
 ##########################################################################
 


### PR DESCRIPTION
The CMAKE_BUILD_TYPE MinSizeRel is currently not recognized so that
the build system falls back to Release. In contrast to Release,
MinSizeRel advises the compiler to optimize for size instead of speed
which is particularly interesting on micro controllers. For GCC
CMake will typically specify the option -Os instead of -O3.
