### PR TITLE
Add additional macros and identification variable

### DIFF
--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -347,3 +347,37 @@ function(avr_target_link_libraries EXECUTABLE_TARGET)
 
    target_link_libraries(${TARGET_LIST} ${NON_TARGET_LIST})
 endfunction(avr_target_link_libraries EXECUTABLE_TARGET)
+
+##########################################################################
+# avr_target_include_directories
+#
+# Calls target_include_directories with AVR target names
+##########################################################################
+
+function(avr_target_include_directories EXECUTABLE_TARGET)
+   if(NOT ARGN)
+      message(FATAL_ERROR "No include directories to add to ${EXECUTABLE_TARGET}.")
+   endif()
+
+   get_target_property(TARGET_LIST ${EXECUTABLE_TARGET} OUTPUT_NAME)
+   set(extra_args ${ARGN})
+
+   target_include_directories(${TARGET_LIST} ${extra_args})
+endfunction()
+
+##########################################################################
+# avr_target_compile_definitions
+#
+# Calls target_compile_definitions with AVR target names
+##########################################################################
+
+function(avr_target_compile_definitions EXECUTABLE_TARGET)
+   if(NOT ARGN)
+      message(FATAL_ERROR "No compile definitions to add to ${EXECUTABLE_TARGET}.")
+   endif()
+
+   get_target_property(TARGET_LIST ${EXECUTABLE_TARGET} OUTPUT_NAME)
+   set(extra_args ${ARGN})
+
+   target_compile_definitions(${TARGET_LIST} ${extra_args})
+endfunction()

--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -51,6 +51,11 @@ set(CMAKE_C_COMPILER ${AVR_CC})
 set(CMAKE_CXX_COMPILER ${AVR_CXX})
 
 ##########################################################################
+# Identification
+##########################################################################
+set(AVR 1)
+
+##########################################################################
 # some necessary tools and variables for AVR builds, which may not
 # defined yet
 # - AVR_UPLOADTOOL


### PR DESCRIPTION
* Add additional macros for target_include_directories and target_compile_definitions
* Add identification variable AVR, which is very useful for cross-platform cmake configurations (e.g. AVR and Raspi, depending on tool chain)