### PR TITLE
Fix multiple use of add_avr_executable

### DIFF
--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -230,55 +230,14 @@ function(add_avr_executable EXECUTABLE_NAME)
       COMMENT "Uploading ${eeprom_image} to ${AVR_MCU} using ${AVR_PROGRAMMER}"
    )
 
-   # get status
-   add_custom_target(
-      get_status
-      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n -v
-      COMMENT "Get status from ${AVR_MCU}"
-   )
-
-   # get fuses
-   add_custom_target(
-      get_fuses
-      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n
-         -U lfuse:r:-:b
-         -U hfuse:r:-:b
-      COMMENT "Get fuses from ${AVR_MCU}"
-   )
-
-   # set fuses
-   add_custom_target(
-      set_fuses
-      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-         -U lfuse:w:${AVR_L_FUSE}:m
-         -U hfuse:w:${AVR_H_FUSE}:m
-         COMMENT "Setup: High Fuse: ${AVR_H_FUSE} Low Fuse: ${AVR_L_FUSE}"
-   )
-
-   # get oscillator calibration
-   add_custom_target(
-      get_calibration
-         ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-         -U calibration:r:${AVR_MCU}_calib.tmp:r
-         COMMENT "Write calibration status of internal oscillator to ${AVR_MCU}_calib.tmp."
-   )
-
-   # set oscillator calibration
-   add_custom_target(
-      set_calibration
-      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-         -U calibration:w:${AVR_MCU}_calib.hex
-         COMMENT "Program calibration status of internal oscillator from ${AVR_MCU}_calib.hex."
-   )
-
    # disassemble
    add_custom_target(
       disassemble_${EXECUTABLE_NAME}
       ${AVR_OBJDUMP} -h -S ${elf_file} > ${EXECUTABLE_NAME}.lst
       DEPENDS ${elf_file}
    )
-
 endfunction(add_avr_executable)
+
 
 ##########################################################################
 # add_avr_library
@@ -381,3 +340,44 @@ function(avr_target_compile_definitions EXECUTABLE_TARGET)
 
    target_compile_definitions(${TARGET_LIST} ${extra_args})
 endfunction()
+
+# get status
+add_custom_target(
+   get_status
+   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n -v
+   COMMENT "Get status from ${AVR_MCU}"
+)
+
+# get fuses
+add_custom_target(
+   get_fuses
+   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n
+      -U lfuse:r:-:b
+      -U hfuse:r:-:b
+   COMMENT "Get fuses from ${AVR_MCU}"
+)
+
+# set fuses
+add_custom_target(
+   set_fuses
+   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
+      -U lfuse:w:${AVR_L_FUSE}:m
+      -U hfuse:w:${AVR_H_FUSE}:m
+      COMMENT "Setup: High Fuse: ${AVR_H_FUSE} Low Fuse: ${AVR_L_FUSE}"
+)
+
+# get oscillator calibration
+add_custom_target(
+   get_calibration
+      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
+      -U calibration:r:${AVR_MCU}_calib.tmp:r
+      COMMENT "Write calibration status of internal oscillator to ${AVR_MCU}_calib.tmp."
+)
+
+# set oscillator calibration
+add_custom_target(
+   set_calibration
+   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
+      -U calibration:w:${AVR_MCU}_calib.hex
+      COMMENT "Program calibration status of internal oscillator from ${AVR_MCU}_calib.hex."
+)

--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -222,7 +222,7 @@ function(add_avr_executable EXECUTABLE_NAME)
    # upload eeprom only - with avrdude
    # see also bug http://savannah.nongnu.org/bugs/?40142
    add_custom_target(
-      upload_eeprom
+      upload_${EXECUTABLE_NAME}_eeprom
       ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} ${AVR_UPLOADTOOL_OPTIONS}
          -U eeprom:w:${eeprom_image}
          -P ${AVR_UPLOADTOOL_PORT}

--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -341,43 +341,45 @@ function(avr_target_compile_definitions EXECUTABLE_TARGET)
    target_compile_definitions(${TARGET_LIST} ${extra_args})
 endfunction()
 
-# get status
-add_custom_target(
-   get_status
-   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n -v
-   COMMENT "Get status from ${AVR_MCU}"
-)
-
-# get fuses
-add_custom_target(
-   get_fuses
-   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n
-      -U lfuse:r:-:b
-      -U hfuse:r:-:b
-   COMMENT "Get fuses from ${AVR_MCU}"
-)
-
-# set fuses
-add_custom_target(
-   set_fuses
-   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-      -U lfuse:w:${AVR_L_FUSE}:m
-      -U hfuse:w:${AVR_H_FUSE}:m
-      COMMENT "Setup: High Fuse: ${AVR_H_FUSE} Low Fuse: ${AVR_L_FUSE}"
-)
-
-# get oscillator calibration
-add_custom_target(
-   get_calibration
+function(avr_generate_fixed_targets)
+   # get status
+   add_custom_target(
+      get_status
+      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n -v
+      COMMENT "Get status from ${AVR_MCU}"
+   )
+   
+   # get fuses
+   add_custom_target(
+      get_fuses
+      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT} -n
+         -U lfuse:r:-:b
+         -U hfuse:r:-:b
+      COMMENT "Get fuses from ${AVR_MCU}"
+   )
+   
+   # set fuses
+   add_custom_target(
+      set_fuses
       ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-      -U calibration:r:${AVR_MCU}_calib.tmp:r
-      COMMENT "Write calibration status of internal oscillator to ${AVR_MCU}_calib.tmp."
-)
-
-# set oscillator calibration
-add_custom_target(
-   set_calibration
-   ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
-      -U calibration:w:${AVR_MCU}_calib.hex
-      COMMENT "Program calibration status of internal oscillator from ${AVR_MCU}_calib.hex."
-)
+         -U lfuse:w:${AVR_L_FUSE}:m
+         -U hfuse:w:${AVR_H_FUSE}:m
+         COMMENT "Setup: High Fuse: ${AVR_H_FUSE} Low Fuse: ${AVR_L_FUSE}"
+   )
+   
+   # get oscillator calibration
+   add_custom_target(
+      get_calibration
+         ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
+         -U calibration:r:${AVR_MCU}_calib.tmp:r
+         COMMENT "Write calibration status of internal oscillator to ${AVR_MCU}_calib.tmp."
+   )
+   
+   # set oscillator calibration
+   add_custom_target(
+      set_calibration
+      ${AVR_UPLOADTOOL} -p ${AVR_MCU} -c ${AVR_PROGRAMMER} -P ${AVR_UPLOADTOOL_PORT}
+         -U calibration:w:${AVR_MCU}_calib.hex
+         COMMENT "Program calibration status of internal oscillator from ${AVR_MCU}_calib.hex."
+   )
+endfunction()


### PR DESCRIPTION
This PR fixes problems when using `add_avr_executable` more than once by disambiguating targets with the same name.

Currently, when adding several images, you get:
```
Make Error at generic-gcc-avr.cmake:224 (add_custom_target):
  add_custom_target cannot create target "upload_eeprom" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory "...".
  See documentation for policy CMP0002 for more details.
```

The problem was solved in several steps:
1. The target `upload_eeprom` was renamed `upload_${EXECUTABLE_NAME}_eeprom`
2. The targets `get_status`, `get_fuses`, `set_fuses`, `get_calibration`, and `set_calibration` were moved inside a new function, since they are stand-alone and don't depend on the executable target. The user has to explicitly call `avr_generate_fixed_targets()`.

Please note that this PR changes the usage.