### PR TITLE
Add REQUIRED to the avr-gcc, avr-g++, executables

### DIFF
--- a/generic-gcc-avr.cmake
+++ b/generic-gcc-avr.cmake
@@ -36,11 +36,11 @@ option(WITH_MCU "Add the mCU type to the target file name." ON)
 ##########################################################################
 # executables in use
 ##########################################################################
-find_program(AVR_CC avr-gcc)
-find_program(AVR_CXX avr-g++)
-find_program(AVR_OBJCOPY avr-objcopy)
-find_program(AVR_SIZE_TOOL avr-size)
-find_program(AVR_OBJDUMP avr-objdump)
+find_program(AVR_CC avr-gcc REQUIRED)
+find_program(AVR_CXX avr-g++ REQUIRED)
+find_program(AVR_OBJCOPY avr-objcopy REQUIRED)
+find_program(AVR_SIZE_TOOL avr-size REQUIRED)
+find_program(AVR_OBJDUMP avr-objdump REQUIRED)
 
 ##########################################################################
 # toolchain starts with defining mandatory variables


### PR DESCRIPTION
This is a suggestion of getting clearer messages at the moment that the
files can't be found.  This helps in particular to show where the lack
of finding is happening, so people can check their path.